### PR TITLE
Change restart settings for Zookeeper and Kafka

### DIFF
--- a/roles/kafka/templates/kafka-systemd.j2
+++ b/roles/kafka/templates/kafka-systemd.j2
@@ -10,7 +10,10 @@ Environment='KAFKA_HEAP_OPTS=-Xmx16G -Xms16G'
 Environment='KAFKA_JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.rmi.port={{ jmx_port }} '
 CHDIR= {{ kafka.data_dir }}
 ExecStart={{ kafka_dir }}/bin/kafka-server-start.sh {{ kafka_dir }}/config/real-server.properties
-Restart=on-abort
+Restart=always
+RestartSec=30
+StartLimitInterval=120
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/zookeeper/templates/zookeeper-systemd.j2
+++ b/roles/zookeeper/templates/zookeeper-systemd.j2
@@ -9,7 +9,10 @@ User=zookeeper
 Environment=ZOO_LOG_DIR={{ zk.data_dir }}/log JAVA_HOME=/usr/local/java8
 CHDIR= {{ zk.data_dir }}
 ExecStart={{ zk_dir }}/bin/zkServer.sh start
-Restart=on-abort
+Restart=always
+RestartSec=30
+StartLimitInterval=120
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #2 

Set `RestartSec`, `StartLimitInterval` and `StartLimitBurst` in attempt to allow cluster to recover after power cut (restarting failed due to DHCP server not being back up for some time). 